### PR TITLE
Update for 1.20.4 compatibility

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,14 +3,14 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/develop
-	minecraft_version=1.20.1
-	yarn_mappings=1.20.1+build.10
+	minecraft_version=1.20.4
+	yarn_mappings=1.20.4+build.3
 	loader_version=0.14.22
 
 # Mod Properties
-	mod_version = 0.0.1-1.20.1
+	mod_version = 0.0.1-1.20.4
 	maven_group = net.daphysikist
 	archives_base_name = leashableboats
 
 # Dependencies
-	fabric_version=0.86.1+1.20.1
+	fabric_version=0.93.1+1.20.4

--- a/src/main/java/net/daphysikist/leashableboats/mixin/leashableboatmixins/LeashableBoats.java
+++ b/src/main/java/net/daphysikist/leashableboats/mixin/leashableboatmixins/LeashableBoats.java
@@ -97,7 +97,7 @@ import java.util.UUID;
         }
 
         @Inject (method = "updateTrackedPositionAndAngles", at = @At("TAIL"))
-        public void injectUpdateTrackedPositionAndAngles(double x, double y, double z, float yaw, float pitch, int interpolationSteps, boolean interpolate, CallbackInfo cir){
+        public void injectUpdateTrackedPositionAndAngles(double x, double y, double z, float yaw, float pitch, int interpolationSteps, CallbackInfo cir){
             prevBoatYaw = yaw;
         }
 


### PR DESCRIPTION
Updates the mod to be compatible with 1.20.4

In LeashableBoats.java, an injection for method updateTrackedPositionAndAngles needed an update in the method signature since the yarn mappings seem to have changed:

v1.20.1+build.10 API (broken in 1.20.4):
https://maven.fabricmc.net/docs/yarn-1.20.1+build.10/net/minecraft/entity/vehicle/BoatEntity.html#updateTrackedPositionAndAngles(double,double,double,float,float,int,boolean)

v 1.20.4+build.3 API (updated):
https://maven.fabricmc.net/docs/yarn-1.20.4+build.3/net/minecraft/entity/vehicle/BoatEntity.html#updateTrackedPositionAndAngles(double,double,double,float,float,int)

Also updates the gradle settings to reflect updated dependencies and new mod version.

I have used the mod on 1.24 for a few hours without further issues, boat leashing and renaming works, but I did no further testing. 

I am no MC modder, I just wanted to fix this for myself, so I am likely to have missed something. Even though this seems like a simple fix.